### PR TITLE
fix: Add mailto prefix

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -64,7 +64,7 @@ Its address is:
 
 And its VAT number is **FR41 934 149 618** (see the symmetry?).
 
-The owner and manager of bearcove is Amos Wenger, you can reach them at [admin@bearcove.eu](admin@bearcove.eu).
+The owner and manager of bearcove is Amos Wenger, you can reach them at [admin@bearcove.eu](mailto:admin@bearcove.eu).
 
 This website and other bearcove properties like [fasterthanli.me](https://fasterthanli.me) are
 hosted on [Hetzner](https://hetzner.com), whereas DNS is handled by [gcore](https://gcore.com).


### PR DESCRIPTION
Currently it redirects to https://bearcove.eu/admin@bearcove.eu which is a 404. Fix changes it to a mailto link